### PR TITLE
Fix heightNotifier bug

### DIFF
--- a/lib/src/scroll_bars_controller.dart
+++ b/lib/src/scroll_bars_controller.dart
@@ -80,7 +80,8 @@ abstract class ScrollBarsController {
     _oldOffset = pixels;
 
     if (position.axisDirection == AxisDirection.down &&
-        position.extentAfter == 0.0) {
+        position.extentAfter == 0.0 &&
+        position.maxScrollExtent > height) {
       if (heightNotifier.value == 0.0) return;
       heightNotifier.value = 0.0;
       return;


### PR DESCRIPTION
Without this change, in cases where `0 < position.maxScrollExtent < height`, the `AppBar` will collapse (with `heightNotifier.value == 0.0`) and not be able to uncollapse, as the view will no longer be scrollable (because the `AppBar` is collapsed &  its height is missing)